### PR TITLE
type on op$carryover_scalefactor

### DIFF
--- a/R/lme_analysis.R
+++ b/R/lme_analysis.R
@@ -106,7 +106,7 @@ lme_analysis<-function(trialdesign_set,dat,op){
     # more complex carryover modeling
     data.m2[,Dbc:=as.numeric(NA)]
     data.m2[Db==TRUE,Dbc:=1]
-    data.m2[Db==FALSE,Dbc:=((1/2)^(op*carryover_scalefactor*tsd/op$carryover_t1half))]
+    data.m2[Db==FALSE,Dbc:=((1/2)^(op$carryover_scalefactor*tsd/op$carryover_t1half))]
 
     datout[[g]]<-data.m2
   }

--- a/vignettes/Produce_Publication_Results_1_generate_data.Rmd
+++ b/vignettes/Produce_Publication_Results_1_generate_data.Rmd
@@ -358,13 +358,13 @@ numbers of repetitions and then rejoin them you can do so, as long as they have 
 ```{r}
 # Set the number of reptitions. Was 1,000 in the publication
 Nreps<-2
-
 # Flag to keep this code from actually running for now - flip to try it
-rerun_simulations<-FALSE
+rerun_simulations<-TRUE
 
 if(rerun_simulations){
   # This block runs the paramater sets that explore the impact of N, biomarker effect size, 
   # and carryover
+  browser()
   simresults<-generateSimulatedResults(
     trialdesigns=list(trialdesigns$OL,trialdesigns$OLBDC,trialdesigns$CO,trialdesigns$Nof1),
     respparamsets=origrespparamsets[1],


### PR DESCRIPTION
replaced * with $   
data.m2[Db==FALSE,Dbc:=((1/2)^(op*carryover_scalefactor*tsd/op$carryover_t1half))]
 data.m2[Db==FALSE,Dbc:=((1/2)^(op$carryover_scalefactor*tsd/op$carryover_t1half))]